### PR TITLE
[#5] 일반 아이템 목록과 휴지통 아이템 목록 서로 이동 가능하도록 구현

### DIFF
--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/Item.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/Item.kt
@@ -1,7 +1,7 @@
 package com.hongstudio.flabrecyclerviewassignment
 
-data class TrashItem(
+data class Item(
     val id: Long,
     val title: String,
-    val timeoutSecond: Int
+    val timeoutSecond: Int = 0
 )

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainActivity.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
 
     private val viewModel: MainViewModel by viewModels()
-    private val normalItemListAdapter = NormalItemListAdapter()
+    private val normalItemListAdapter = NormalItemListAdapter(::onTrashIconClick)
     private val trashItemListAdapter = TrashItemListAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,14 +30,26 @@ class MainActivity : AppCompatActivity() {
             insets
         }
 
+        setAdapters()
+        setObservers()
+    }
+
+    private fun setAdapters() {
         binding.recyclerViewNormalItems.adapter = normalItemListAdapter
+        binding.recyclerViewTrashItems.adapter = trashItemListAdapter
+    }
+
+    private fun setObservers() {
         viewModel.normalItems.asLiveData().observe(this) {
             normalItemListAdapter.submitList(it)
         }
 
-        binding.recyclerViewTrashItems.adapter = trashItemListAdapter
         viewModel.trashItems.asLiveData().observe(this) {
             trashItemListAdapter.submitList(it)
         }
+    }
+
+    private fun onTrashIconClick(item: Item) {
+        viewModel.onTrashIconClick(item)
     }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainActivity.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
 
     private val viewModel: MainViewModel by viewModels()
     private val normalItemListAdapter = NormalItemListAdapter(::onTrashIconClick)
-    private val trashItemListAdapter = TrashItemListAdapter()
+    private val trashItemListAdapter = TrashItemListAdapter(::onTrashItemClick)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,5 +51,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun onTrashIconClick(item: Item) {
         viewModel.onTrashIconClick(item)
+    }
+
+    private fun onTrashItemClick(item: Item) {
+        viewModel.onTrashItemClick(item)
     }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainViewModel.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainViewModel.kt
@@ -37,4 +37,17 @@ class MainViewModel : ViewModel() {
             newItems.toList()
         }
     }
+
+    fun onTrashItemClick(item: Item) {
+        _normalItems.update {
+            val newItems = it.toMutableList()
+            newItems.add(item)
+            newItems.toList()
+        }
+        _trashItems.update {
+            val newItems = it.toMutableList()
+            newItems.remove(item)
+            newItems.toList()
+        }
+    }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainViewModel.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/MainViewModel.kt
@@ -3,35 +3,38 @@ package com.hongstudio.flabrecyclerviewassignment
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 class MainViewModel : ViewModel() {
-    private val _normalItems: MutableStateFlow<List<NormalItem>> = MutableStateFlow(
+    private val _normalItems: MutableStateFlow<List<Item>> = MutableStateFlow(
         listOf(
-            NormalItem(id = 1, title = "Item 1"),
-            NormalItem(id = 2, title = "Item 2"),
-            NormalItem(id = 3, title = "Item 3"),
-            NormalItem(id = 4, title = "Item 4"),
-            NormalItem(id = 5, title = "Item 5"),
-            NormalItem(id = 6, title = "Item 6"),
-            NormalItem(id = 7, title = "Item 7"),
-            NormalItem(id = 8, title = "Item 8"),
-            NormalItem(id = 9, title = "Item 9"),
-            NormalItem(id = 10, title = "Item 10")
+            Item(id = 1, title = "Item 1"),
+            Item(id = 2, title = "Item 2"),
+            Item(id = 3, title = "Item 3"),
+            Item(id = 4, title = "Item 4"),
+            Item(id = 5, title = "Item 5"),
+            Item(id = 6, title = "Item 6"),
+            Item(id = 7, title = "Item 7"),
+            Item(id = 8, title = "Item 8"),
+            Item(id = 9, title = "Item 9"),
+            Item(id = 10, title = "Item 10")
         )
     )
     val normalItems = _normalItems.asStateFlow()
 
-    private val _trashItems: MutableStateFlow<List<TrashItem>> = MutableStateFlow(
-        listOf(
-            TrashItem(id = 1, title = "Item 1", timeoutSecond = 3),
-            TrashItem(id = 2, title = "Item 2", timeoutSecond = 3),
-            TrashItem(id = 3, title = "Item 3", timeoutSecond = 3),
-            TrashItem(id = 4, title = "Item 4", timeoutSecond = 3),
-            TrashItem(id = 5, title = "Item 5", timeoutSecond = 3),
-            TrashItem(id = 6, title = "Item 6", timeoutSecond = 3),
-            TrashItem(id = 7, title = "Item 7", timeoutSecond = 3)
-        )
-    )
+    private val _trashItems: MutableStateFlow<List<Item>> = MutableStateFlow(listOf())
     val trashItems = _trashItems.asStateFlow()
 
+    fun onTrashIconClick(item: Item) {
+        _normalItems.update {
+            val newItems = it.toMutableList()
+            newItems.remove(item)
+            newItems.toList()
+        }
+        _trashItems.update {
+            val newItems = it.toMutableList()
+            newItems.add(item)
+            newItems.toList()
+        }
+    }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItem.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItem.kt
@@ -1,6 +1,0 @@
-package com.hongstudio.flabrecyclerviewassignment
-
-data class NormalItem(
-    val id: Long,
-    val title: String
-)

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItemListAdapter.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItemListAdapter.kt
@@ -6,12 +6,14 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import androidx.recyclerview.widget.ListAdapter
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemNormalBinding
 
-class NormalItemListAdapter : ListAdapter<NormalItem, NormalItemViewHolder>(
-    object : ItemCallback<NormalItem>() {
-        override fun areItemsTheSame(oldItem: NormalItem, newItem: NormalItem) =
+class NormalItemListAdapter(
+    private val onTrashIconClick: (Item) -> Unit
+) : ListAdapter<Item, NormalItemViewHolder>(
+    object : ItemCallback<Item>() {
+        override fun areItemsTheSame(oldItem: Item, newItem: Item) =
             oldItem.id == newItem.id
 
-        override fun areContentsTheSame(oldItem: NormalItem, newItem: NormalItem) =
+        override fun areContentsTheSame(oldItem: Item, newItem: Item) =
             oldItem == newItem
     }
 ) {
@@ -21,7 +23,8 @@ class NormalItemListAdapter : ListAdapter<NormalItem, NormalItemViewHolder>(
                 LayoutInflater.from(parent.context),
                 parent,
                 false
-            )
+            ),
+            onTrashIconClick
         )
     }
 

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItemViewHolder.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/NormalItemViewHolder.kt
@@ -3,8 +3,14 @@ package com.hongstudio.flabrecyclerviewassignment
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemNormalBinding
 
-class NormalItemViewHolder(private val binding: ItemNormalBinding) : ViewHolder(binding.root) {
-    fun bind(normalItem: NormalItem) {
-        binding.textViewNormalItem.text = normalItem.title
+class NormalItemViewHolder(
+    private val binding: ItemNormalBinding,
+    private val onTrashIconClick: (Item) -> Unit
+) : ViewHolder(binding.root) {
+    fun bind(item: Item) {
+        binding.textViewNormalItem.text = item.title
+        binding.imageViewTrashCan.setOnClickListener {
+            onTrashIconClick(item)
+        }
     }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemListAdapter.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemListAdapter.kt
@@ -6,12 +6,12 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import androidx.recyclerview.widget.ListAdapter
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemTrashBinding
 
-class TrashItemListAdapter : ListAdapter<TrashItem, TrashItemViewHolder>(
-    object : ItemCallback<TrashItem>() {
-        override fun areItemsTheSame(oldItem: TrashItem, newItem: TrashItem) =
+class TrashItemListAdapter : ListAdapter<Item, TrashItemViewHolder>(
+    object : ItemCallback<Item>() {
+        override fun areItemsTheSame(oldItem: Item, newItem: Item) =
             oldItem.id == newItem.id
 
-        override fun areContentsTheSame(oldItem: TrashItem, newItem: TrashItem) =
+        override fun areContentsTheSame(oldItem: Item, newItem: Item) =
             oldItem == newItem
     }
 ) {

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemListAdapter.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemListAdapter.kt
@@ -6,7 +6,9 @@ import androidx.recyclerview.widget.DiffUtil.ItemCallback
 import androidx.recyclerview.widget.ListAdapter
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemTrashBinding
 
-class TrashItemListAdapter : ListAdapter<Item, TrashItemViewHolder>(
+class TrashItemListAdapter(
+    private val onTrashItemClick: (Item) -> Unit
+) : ListAdapter<Item, TrashItemViewHolder>(
     object : ItemCallback<Item>() {
         override fun areItemsTheSame(oldItem: Item, newItem: Item) =
             oldItem.id == newItem.id
@@ -21,7 +23,8 @@ class TrashItemListAdapter : ListAdapter<Item, TrashItemViewHolder>(
                 LayoutInflater.from(parent.context),
                 parent,
                 false
-            )
+            ),
+            onTrashItemClick
         )
     }
 

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemViewHolder.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemViewHolder.kt
@@ -3,11 +3,18 @@ package com.hongstudio.flabrecyclerviewassignment
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemTrashBinding
 
-class TrashItemViewHolder(private val binding: ItemTrashBinding) : ViewHolder(binding.root) {
+class TrashItemViewHolder(
+    private val binding: ItemTrashBinding,
+    private val onTrashItemClick: (Item) -> Unit
+) : ViewHolder(binding.root) {
+
     fun bind(item: Item) {
         binding.textViewTrashItem.text = item.title
         binding.textViewTimeout.run {
             text = context.getString(R.string.trash_items_timeout_second, item.timeoutSecond)
+        }
+        binding.root.setOnClickListener {
+            onTrashItemClick(item)
         }
     }
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemViewHolder.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/TrashItemViewHolder.kt
@@ -4,10 +4,10 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemTrashBinding
 
 class TrashItemViewHolder(private val binding: ItemTrashBinding) : ViewHolder(binding.root) {
-    fun bind(trashItem: TrashItem) {
-        binding.textViewTrashItem.text = trashItem.title
+    fun bind(item: Item) {
+        binding.textViewTrashItem.text = item.title
         binding.textViewTimeout.run {
-            text = context.getString(R.string.trash_items_timeout_second, trashItem.timeoutSecond)
+            text = context.getString(R.string.trash_items_timeout_second, item.timeoutSecond)
         }
     }
 }


### PR DESCRIPTION
## Issue
- #5 

## Description
- 좌측 아이템 목록에서 휴지통 아이콘을 누르면 우측 휴지통 목록으로 이동
- 우측 휴지통 목록에서 아이템을 누르면 좌측 아이템 목록으로 이동시켜서 복구