### PR TITLE
[#11] 일반 아이템 목록의 휴지통 아이콘이 너무 작아서 클릭이 잘 안되는 문제

### DIFF
--- a/app/src/main/res/layout/item_normal.xml
+++ b/app/src/main/res/layout/item_normal.xml
@@ -3,13 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tool="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:padding="16dp">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/imageViewTrashCan"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:padding="16dp"
         android:src="@drawable/trash_can"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/textViewNormalItem"


### PR DESCRIPTION
## Issue
- #11 

## Description
### Issue
일반 아이템 목록의 휴지통 아이콘이 너무 작아서 클릭이 잘 안되는 문제

### Solution
휴지통 아이콘에 대해 padding을 주어, 클릭 가능한 영역 조금 더 넓게 수정
