### PR TITLE
[#13] RecyclerView 아이템의 개수가 늘어났을 때 Navigation Bar에 의해 최하단이 가려지는 문제

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,8 +22,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewNormalItems"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/recyclerViewTrashItems"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/textViewNormalItemsTitle" />
@@ -43,8 +44,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerViewTrashItems"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/recyclerViewNormalItems"
         app:layout_constraintTop_toBottomOf="@id/textViewNormalItemsTitle" />


### PR DESCRIPTION
## Issue
- #13 

## Description
- RecyclerView 아이템의 개수가 늘어났을 때 Navigation Bar에 의해 최하단이 가려지는 문제
    - 일반 아이템 목록과 휴지통 아이템 목록 둘다 수정 필요