### PR TITLE
[#23] 카운트다운을 위한 timeoutSecond를 아이템마다 부여

### DIFF
--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/model/Item.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/model/Item.kt
@@ -1,5 +1,7 @@
 package com.hongstudio.flabrecyclerviewassignment.model
 
+import com.hongstudio.flabrecyclerviewassignment.common.TimeoutSecond
+
 sealed interface Item {
     val id: Long
     val title: String
@@ -11,6 +13,7 @@ sealed interface Item {
 
     data class Trash(
         override val id: Long,
-        override val title: String
+        override val title: String,
+        val timeoutSecond : Int = TimeoutSecond.INITIAL_TIMEOUT_SECOND
     ) : Item
 }

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/MainActivity.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/MainActivity.kt
@@ -62,14 +62,6 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.timeoutSecond.collectLatest {
-                    trashItemListAdapter.updateTimeout(it)
-                }
-            }
-        }
     }
 
     private fun onTrashIconClick(item: Item) {

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/MainAdapter.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/MainAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.hongstudio.flabrecyclerviewassignment.common.TimeoutSecond
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemNormalBinding
 import com.hongstudio.flabrecyclerviewassignment.databinding.ItemTrashBinding
 import com.hongstudio.flabrecyclerviewassignment.model.Item
@@ -21,8 +20,6 @@ class MainAdapter(
         override fun areContentsTheSame(oldItem: Item, newItem: Item): Boolean = oldItem == newItem
     }
 ) {
-    private var timeoutSecond: Int = TimeoutSecond.INITIAL_TIMEOUT_SECOND
-
     override fun getItemViewType(position: Int): Int {
         return when (getItem(position)) {
             is Item.Normal -> TYPE_NORMAL
@@ -55,13 +52,8 @@ class MainAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is NormalItemViewHolder -> holder.bind(getItem(position))
-            is TrashItemViewHolder -> holder.bind(getItem(position), timeoutSecond)
+            is TrashItemViewHolder -> holder.bind(getItem(position))
         }
-    }
-
-    fun updateTimeout(timeoutSecond: Int) {
-        this.timeoutSecond = timeoutSecond
-        notifyItemRangeChanged(0, itemCount)
     }
 
     companion object {

--- a/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/TrashItemViewHolder.kt
+++ b/app/src/main/java/com/hongstudio/flabrecyclerviewassignment/view/TrashItemViewHolder.kt
@@ -10,10 +10,12 @@ class TrashItemViewHolder(
     private val onTrashItemClick: (Item) -> Unit
 ) : ViewHolder(binding.root) {
 
-    fun bind(item: Item, timeoutSecond: Int) {
+    fun bind(item: Item) {
         binding.textViewTrashItem.text = item.title
-        binding.textViewTimeout.run {
-            text = context.getString(R.string.trash_items_timeout_second, timeoutSecond)
+        if (item is Item.Trash) {
+            binding.textViewTimeout.run {
+                text = context.getString(R.string.trash_items_timeout_second, item.timeoutSecond)
+            }
         }
         binding.root.setOnClickListener {
             onTrashItemClick(item)


### PR DESCRIPTION
## Issue
- #23 

## Description
- 현재 코드는 timeoutSecond를 ViewModel에서 통합적으로 관리
- timeoutSecond를 휴지통 아이템마다 각각 관리하는 것으로 변경